### PR TITLE
Ignore assert deprecation errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,18 @@ module.exports = {
     "no-multi-spaces": "off",
     "comma-dangle": "off",
     "flowtype/define-flow-type": 1,
-    "flowtype/use-flow-type": 1
+    "flowtype/use-flow-type": 1,
+    "node/no-deprecated-api": [
+      "error",
+      {
+        // To ignore these errors, we need to omit support Node.js < 9.9.x
+        ignoreModuleItems: [
+          "assert.deepEqual",
+          "assert.equal",
+          "assert.notDeepEqual",
+          "assert.notEqual"
+        ]
+      }
+    ]
   }
 };


### PR DESCRIPTION
The new version of eslint-plugin-node published.

To merge https://github.com/Leko/zapshot/pull/28, we need to except these rules.