### PR TITLE
in CI columns might return 0. default to 80

### DIFF
--- a/packages/zapshot-cli/src/progress-logger.js
+++ b/packages/zapshot-cli/src/progress-logger.js
@@ -7,7 +7,7 @@ export class ProgressLogger implements Logger {
 
   constructor() {
     // $FlowFixMe(stdout-has-columns)
-    this.width = process.stdout.columns;
+    this.width = process.stdout.columns || 80;
     this.eraser = `\r${" ".repeat(this.width)}\r`;
   }
 
@@ -20,7 +20,7 @@ export class ProgressLogger implements Logger {
         String(total).length +
         etaHumanized.length +
         7);
-    const fillWidth = Math.round(restWidth / total * tick);
+    const fillWidth = Math.round((restWidth / total) * tick);
     const fillBar = "█".repeat(fillWidth);
     const restBar = "░".repeat(restWidth - fillWidth);
     process.stdout.write(


### PR DESCRIPTION
Hey I was trying to use this in circleCI and I got the following error

```
$ zapshot --step 500 --threshold 15 performance.test.js
RangeError: Invalid count value
    at String.repeat (native)
    at ProgressLogger.log (/home/circleci/compose-tiny/node_modules/zapshot-cli/dist/progress-logger.js:38:25)
    at Progress.<anonymous> (/home/circleci/compose-tiny/node_modules/zapshot/dist/progress.js:71:21)
    at Progress.tick (/home/circleci/compose-tiny/node_modules/zapshot/dist/progress.js:53:22)
    at measure (/home/circleci/compose-tiny/node_modules/zapshot/dist/measure.js:133:12)
    at /home/circleci/compose-tiny/node_modules/zapshot-cli/dist/cli.js:42:54
    at Generator.next (<anonymous>)
    at step (/home/circleci/compose-tiny/node_modules/zapshot-cli/dist/cli.js:22:221)
    at _next (/home/circleci/compose-tiny/node_modules/zapshot-cli/dist/cli.js:22:409)
    at /home/circleci/compose-tiny/node_modules/zapshot-cli/dist/cli.js:22:477
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Exited with code 1
```

I tracked it down to the CLI logger. In circle it seems `process.stdout.columns` is returning 0. This causes the above error when constructing the loading bar. All my change does is set the width to 80 if `columns` returns 0